### PR TITLE
change compatibility comparison to match decompilation

### DIFF
--- a/PokeNavEggs/Form1.cs
+++ b/PokeNavEggs/Form1.cs
@@ -118,9 +118,9 @@ namespace PokeNavEggs
 
             uint txor = tid ^ sid;
             PokeRNG rng = new PokeRNG(baserng.seed);
-            result.EggRand = rng.nextUShort() * 100 >> 16;
+            result.EggRand = rng.nextUShort() * 100 / 0xFFFF;
 
-            if (compatability > result.EggRand)
+            if (result.EggRand >= compatability)
             {
                 PokeRNG rng2 = new PokeRNG(frame & 0xFFFF);
                 uint low = (rng.nextUShort() % 0xFFFE) + 1;

--- a/PokeNavEggs/Form1.cs
+++ b/PokeNavEggs/Form1.cs
@@ -120,7 +120,7 @@ namespace PokeNavEggs
             PokeRNG rng = new PokeRNG(baserng.seed);
             result.EggRand = rng.nextUShort() * 100 / 0xFFFF;
 
-            if (result.EggRand >= compatability)
+            if (compatability > result.EggRand)
             {
                 PokeRNG rng2 = new PokeRNG(frame & 0xFFFF);
                 uint low = (rng.nextUShort() % 0xFFFE) + 1;

--- a/PokeNavEggs/Form1.cs
+++ b/PokeNavEggs/Form1.cs
@@ -120,7 +120,7 @@ namespace PokeNavEggs
             PokeRNG rng = new PokeRNG(baserng.seed);
             result.EggRand = rng.nextUShort() * 100 >> 16;
 
-            if (result.EggRand <= compatability)
+            if (compatability > result.EggRand)
             {
                 PokeRNG rng2 = new PokeRNG(frame & 0xFFFF);
                 uint low = (rng.nextUShort() % 0xFFFE) + 1;


### PR DESCRIPTION
Fix to comparison between compatibility to match the emerald decompilation and pokefinder, fixes issue where when Egg Rand = compatibility an egg is generated, when it should not be.